### PR TITLE
Fix Nokogiri gem contains several vulnerabilities in libxml2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,8 +53,9 @@ GEM
     minitest (5.8.2)
     multi_json (1.11.1)
     multi_xml (0.5.5)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7.1)
+      mini_portile2 (~> 2.0.0.rc2)
+
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)


### PR DESCRIPTION
**Security Updates**

- Updated [nokogiri](https://rubygems.org/gems/nokogiri) (1.6.7.1)

cc: Shopify/security
Reference: #
